### PR TITLE
Update timezones

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@types/bcrypt": "^6.0.0",
+    "@types/luxon": "^3.7.1",
     "@types/node": "^20.19.35",
     "@types/pg": "^8.18.0",
     "@types/react": "^19.2.14",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@prisma/client": "^7.7.0",
     "bcrypt": "^6.0.0",
     "bootstrap": "^5.3.8",
+    "luxon": "^3.7.2",
     "next": "16.1.6",
     "next-auth": "^5.0.0-beta.30",
     "pg": "^8.19.0",

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -1,28 +1,23 @@
 import SpaceCard from '@/components/SpaceCard';
 import { prisma } from '@/lib/prisma';
 import { Container, Row, Col } from 'react-bootstrap';
+import { DateTime } from 'luxon';
 
 export default async function TodayPage() {
-  const now = new Date();
-  const hawaiiNow = new Date(
-    now.toLocaleString('en-US', { timeZone: 'Pacific/Honolulu' })
-  );
+  // Current time in Hawaii (safe, no string parsing)
+  const hawaiiNow = DateTime.now().setZone('Pacific/Honolulu');
 
-  const formattedDate = hawaiiNow.toLocaleDateString('en-US', {
-    timeZone: 'Pacific/Honolulu',
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  // Format date for display
+  const formattedDate = hawaiiNow.toFormat('EEEE, MMMM d, yyyy');
 
   // Start of today in Hawaii
-  const startOfToday = new Date(hawaiiNow);
-  startOfToday.setHours(0, 0, 0, 0);
+  const startOfToday = hawaiiNow.startOf('day').toJSDate();
 
   // Start of tomorrow in Hawaii
-  const startOfTomorrow = new Date(startOfToday);
-  startOfTomorrow.setDate(startOfTomorrow.getDate() + 1);
+  const startOfTomorrow = hawaiiNow
+    .plus({ days: 1 })
+    .startOf('day')
+    .toJSDate();
 
   const listings = await prisma.listing.findMany({
     where: {

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -19,6 +19,12 @@ export default async function TodayPage() {
     .startOf('day')
     .toJSDate();
 
+  // Time Test
+  console.log("Now (server UTC):", new Date().toISOString());
+  console.log("startOfToday:", startOfToday.toISOString());
+  console.log("startOfTomorrow:", startOfTomorrow.toISOString());
+  console.log("formattedDate:", formattedDate);
+
   const listings = await prisma.listing.findMany({
     where: {
       createdAt: {


### PR DESCRIPTION
This change makes “Today” page to use Luxon for date and timezone handling instead of manual JavaScript Date manipulation. It replaces a fragile approach for calculating Hawaii time with a more reliable DateTime.now().setZone('Pacific/Honolulu'), simplifying how the start of today and tomorrow are computed and improving consistency in date formatting and timezone accuracy.