### PR TITLE
Trying to fix timezones on vercel

### DIFF
--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -3,6 +3,8 @@ import { prisma } from '@/lib/prisma';
 import { Container, Row, Col } from 'react-bootstrap';
 import { DateTime } from 'luxon';
 
+export const dynamic = 'force-dynamic';
+
 export default async function TodayPage() {
   // Current time in Hawaii (safe, no string parsing)
   const hawaiiNow = DateTime.now().setZone('Pacific/Honolulu');


### PR DESCRIPTION
The issue is likely that Vercel is caching the page, causing it to show stale data. I've added export const dynamic = 'force-dynamic'; to force Next.js to always server-render the page dynamically